### PR TITLE
Add Tinyhttp to the list of backend frameworks

### DIFF
--- a/README.mdx
+++ b/README.mdx
@@ -67,6 +67,8 @@ Inspired by 👍 [ziadoz/awesome-php](https://github.com/ziadoz/awesome-php)
 - [Socketstream](http://socketstream.org/) - Socketstream is a framework for Realtime Web Apps
 - [PartialJS](http://www.partialjs.com/) 
 - [MoleculerJS Boilerplate](https://github.com/pankod/moleculerjs-boilerplate) - A well-structured Moleculer JS Boilerplate with Typescript, CLI, Service Helpers, Swagger, Jest support and everything you'll ever need to deploy rock solid projects.
+- [Tinyhttp](https://tinyhttp.v1rtl.site) - modern Express-like web framework written in TypeScript and compiled to native ESM, that uses a bare minimum amount of dependencies trying to avoid legacy hell.
+
 ## CMS
 - [Ghost](https://ghost.org/) - The professional publishing platform developed in NodeJS
 - [Keystone](http://keystonejs.com/) - Node.js CMS & Web Application Platform


### PR DESCRIPTION
tinyhttp is a modern Express-like web framework for Node.js, written in TypeScript and compiled to native ESM. It uses a bare minimum amount of dependencies trying to avoid legacy hell.

:earth_africa:  Website: https://tinyhttp.v1rtl.site
:octocat:  Repo: https://github.com/talentlessguy/tinyhttp

the project itself, at the moment of adding this PR, has 124 stars and 6 (including myself) contributors. Was created on June 13, so more than 30 days passed.

I didn't find any contributing guidelines so I hope my PR is fine :)