### PR TITLE
Add FoalTS to backend frameworks

### DIFF
--- a/README.mdx
+++ b/README.mdx
@@ -68,6 +68,7 @@ Inspired by 👍 [ziadoz/awesome-php](https://github.com/ziadoz/awesome-php)
 - [PartialJS](http://www.partialjs.com/) 
 - [MoleculerJS Boilerplate](https://github.com/pankod/moleculerjs-boilerplate) - A well-structured Moleculer JS Boilerplate with Typescript, CLI, Service Helpers, Swagger, Jest support and everything you'll ever need to deploy rock solid projects.
 - [Tinyhttp](https://tinyhttp.v1rtl.site) - modern Express-like web framework written in TypeScript and compiled to native ESM, that uses a bare minimum amount of dependencies trying to avoid legacy hell.
+- [FoalTS](https://foalts.org) - Elegant and all-inclusive Node.JS framework based on TypeScript
 
 ## CMS
 - [Ghost](https://ghost.org/) - The professional publishing platform developed in NodeJS


### PR DESCRIPTION
Add FoalTS to backend frameworks

Website: https://foalts.org/
Github: https://github.com/FoalTS/foal